### PR TITLE
add NEXT_PUBLIC_PREVLAB_ONRENDER_URL anviroment variable

### DIFF
--- a/services/axiosConfig.js
+++ b/services/axiosConfig.js
@@ -2,6 +2,8 @@ import axios from "axios";
 
 // axios.defaults.baseURL = "http://localhost:3333/api";
 axios.defaults.baseURL =
-  process.env.NEXT_PUBLIC_PREVLAB_HEROKU_URL || "http://localhost:3333/api";
+    process.env.NEXT_PUBLIC_PREVLAB_HEROKU_URL ||
+    NEXT_PUBLIC_PREVLAB_ONRENDER_URL ||
+    "http://localhost:3333/api";
 
 export { axios };


### PR DESCRIPTION
add NEXT_PUBLIC_PREVLAB_ONRENDER_URL environment variable to handle new platform service because heroku is no longer free anymore